### PR TITLE
fix: remove `hyperdyperid` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,7 @@
   "peerDependencies": {
     "tslib": "2"
   },
-  "dependencies": {
-    "hyperdyperid": "^1.2.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/benchmark": "^2.1.2",
     "@types/jest": "^29.5.12",

--- a/src/buffers/utf8/CachedUtf8Decoder.ts
+++ b/src/buffers/utf8/CachedUtf8Decoder.ts
@@ -1,5 +1,12 @@
 import decodeUtf8 from './decodeUtf8/v10';
-import {randomU32} from 'hyperdyperid/lib/randomU32';
+
+let x = 1 + Math.round(Math.random() * ((-1>>>0)-1));
+
+/** Generate a random 32-bit unsigned integer in the specified [min, max] range. */
+function randomU32(min: number, max: number): number {
+  x ^= x << 13; x ^= x >>> 17; x ^= x << 5;
+  return (x >>> 0) % (max - min + 1) + min;
+}
 
 class CacheItem {
   constructor(

--- a/src/buffers/utf8/CachedUtf8Decoder.ts
+++ b/src/buffers/utf8/CachedUtf8Decoder.ts
@@ -1,11 +1,13 @@
 import decodeUtf8 from './decodeUtf8/v10';
 
-let x = 1 + Math.round(Math.random() * ((-1>>>0)-1));
+let x = 1 + Math.round(Math.random() * ((-1 >>> 0) - 1));
 
 /** Generate a random 32-bit unsigned integer in the specified [min, max] range. */
 function randomU32(min: number, max: number): number {
-  x ^= x << 13; x ^= x >>> 17; x ^= x << 5;
-  return (x >>> 0) % (max - min + 1) + min;
+  x ^= x << 13;
+  x ^= x >>> 17;
+  x ^= x << 5;
+  return ((x >>> 0) % (max - min + 1)) + min;
 }
 
 class CacheItem {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1338,11 +1338,6 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-hyperdyperid@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hyperdyperid/-/hyperdyperid-1.2.0.tgz#59668d323ada92228d2a869d3e474d5a33b69e6b"
-  integrity sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==
-
 ignore@^5.3.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"


### PR DESCRIPTION
This package is 1mb in size and has not needed an update in two years so I think it's fairly safe to inline this function